### PR TITLE
Add ClawdTalk skill for phone calling and SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Skills that encode proven workflows and prompts for multi-agent development:
 |-------|-------------|----------|
 | **[csctf](skills/csctf/SKILL.md)** | Chat Shared Conversation To File - convert ChatGPT, Gemini, Grok, and Claude share links to clean Markdown + HTML transcripts | "Save this conversation: https://chatgpt.com/share/..." |
 
+### Communication & Telephony
+
+| Skill | Description | Use Case |
+|-------|-------------|----------|
+| **[clawdtalk](skills/clawdtalk/SKILL.md)** | Phone calling and SMS for OpenClaw. Call your AI agent from any phone with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx. | "Call my AI agent from mobile to check my schedule" |
+
 ### Development Tools
 
 | Skill | Description | Use Case |

--- a/skills/clawdtalk/SKILL.md
+++ b/skills/clawdtalk/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: clawdtalk
+description: "ClawdTalk - Phone calling and SMS for OpenClaw. Call your AI agent from any phone with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx."
+---
+
+# ClawdTalk Skill
+
+Use ClawdTalk to enable phone calling and SMS capabilities for your OpenClaw AI agent. ClawdTalk enables voice interaction through regular phone calls, integrating with tools like calendar, Jira, web search, and more.
+
+## Overview
+
+ClawdTalk connects your AI agent to the regular phone network, allowing:
+- Voice calls to your AI agent from any phone
+- SMS messaging capabilities
+- Deep integration with OpenClaw tools (calendar, Jira, web search)
+- Powered by Telnyx telecommunications infrastructure
+
+## Use Cases
+
+- "Call my AI agent from my mobile phone to check my schedule"
+- "Send an SMS reminder via ClawdTalk"
+- "Have my agent call me when the meeting is ready"
+
+## Setup
+
+1. Get a Telnyx API key from [telnyx.com](https://telnyx.com)
+2. Configure ClawdTalk with your Telnyx credentials
+3. Set up your phone number in ClawdTalk
+
+For full setup instructions, visit the [ClawdTalk GitHub repository](https://github.com/team-telnyx/clawdtalk-client).
+
+## Integration
+
+ClawdTalk integrates with OpenClaw to provide:
+- Voice input/output through phone calls
+- SMS notifications and reminders
+- Calendar integration for scheduling calls
+- Jira integration for task-related notifications
+- Web search capabilities via voice
+
+## Related
+
+- GitHub: [team-telnyx/clawdtalk-client](https://github.com/team-telnyx/clawdtalk-client)
+- Website: [clawdtalk.com](https://clawdtalk.com)


### PR DESCRIPTION
Adds ClawdTalk to the skill library. ClawdTalk provides phone calling and SMS capabilities for OpenClaw agents, enabling voice interaction via Telnyx.\n\nIncludes:\n- New skills/clawdtalk/SKILL.md with full documentation\n- Updated README.md with Communication & Telephony section