### PR TITLE
fix(skills): migrate all bd references to br (beads_rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Skills that encode proven workflows and prompts for multi-agent development:
 | **[ui-ux-polish](skills/ui-ux-polish/SKILL.md)** | Iterative Stripe-level UI polish with exact prompt | "Make this look world-class" |
 | **[de-slopify](skills/de-slopify/SKILL.md)** | Remove AI writing artifacts from documentation | "Clean up the AI slop in this README" |
 | **[tanstack-integration](skills/tanstack-integration/SKILL.md)** | Strategic TanStack library adoption (avoid man-with-hammer) | "Should I use TanStack Query here?" |
+| **[bd-to-br-migration](skills/bd-to-br-migration/SKILL.md)** | Migrate docs from bd (Go) to br (beads_rust) with exact transforms | "Migrate AGENTS.md from bd to br" |
 
 ### Discord Integration
 

--- a/skills/agent-mail/SKILL.md
+++ b/skills/agent-mail/SKILL.md
@@ -145,23 +145,26 @@ Prefer macros for speed and smaller models. Use granular tools when you need fin
 | `macro_file_reservation_cycle` | Reserve files, do work, optionally auto-release when done |
 | `macro_contact_handshake` | Request contact permission, optionally auto-accept, send welcome message |
 
-## Beads Integration (bd-### Workflow)
+## Beads Integration (br-### Workflow)
 
 When using Beads for task management, keep identifiers aligned:
 
 ```
-1. Pick ready work:     bd ready --json → choose bd-123
-2. Reserve files:       file_reservation_paths(..., reason="bd-123")
-3. Announce start:      send_message(..., thread_id="bd-123", subject="[bd-123] Starting...")
+1. Pick ready work:     br ready --json → choose br-123
+2. Reserve files:       file_reservation_paths(..., reason="br-123")
+3. Announce start:      send_message(..., thread_id="br-123", subject="[br-123] Starting...")
 4. Work and update:     Reply in thread with progress
-5. Complete:            bd close bd-123
+5. Complete:            br close br-123
                         release_file_reservations(...)
-                        send_message(..., subject="[bd-123] Completed")
+                        send_message(..., subject="[br-123] Completed")
+6. Sync and commit:     br sync --flush-only
+                        git add .beads/
+                        git commit -m "close br-123"
 ```
 
-Use `bd-###` as:
+Use `br-###` as:
 - Mail `thread_id`
-- Message subject prefix `[bd-###]`
+- Message subject prefix `[br-###]`
 - File reservation `reason`
 - Commit message reference
 

--- a/skills/agent-mail/SKILL.md
+++ b/skills/agent-mail/SKILL.md
@@ -85,7 +85,7 @@ file_reservation_paths(
   paths=["src/auth/**/*.ts", "src/middleware/auth.ts"],
   ttl_seconds=3600,
   exclusive=true,
-  reason="bd-123"
+  reason="br-123"
 )
 ```
 
@@ -100,9 +100,9 @@ send_message(
   project_key="/abs/path/to/project",
   sender_name="GreenCastle",
   to=["BlueLake"],
-  subject="[bd-123] Starting auth refactor",
+  subject="[br-123] Starting auth refactor",
   body_md="Reserving src/auth/**. Will update session handling.",
-  thread_id="bd-123",
+  thread_id="br-123",
   importance="normal",
   ack_required=true
 )
@@ -179,7 +179,7 @@ Use bv's robot flags for intelligent task selection:
 | `bv --robot-priority` | Recommendations with confidence | "What should I work on next?" |
 | `bv --robot-diff --diff-since <ref>` | Changes since commit/date | "What changed?" |
 
-**Rule of thumb:** Use `bd` for task operations, use `bv` for task intelligence.
+**Rule of thumb:** Use `br` for task operations, use `bv` for task intelligence.
 
 ## Cross-Project Coordination
 

--- a/skills/agent-swarm-workflow/SKILL.md
+++ b/skills/agent-swarm-workflow/SKILL.md
@@ -202,7 +202,7 @@ file_reservation_paths(
     paths=["src/auth/**/*.ts"],
     ttl_seconds=3600,
     exclusive=True,
-    reason="bd-123"
+    reason="br-123"
 )
 
 # After completing work
@@ -216,18 +216,18 @@ release_file_reservations(project_key, agent_name)
 send_message(
     project_key, agent_name,
     to=["BlueLake", "RedMountain"],  # Other active agents
-    subject="[bd-123] Starting auth module",
-    body_md="I'm taking bd-123. Reserved src/auth/**.",
-    thread_id="bd-123"
+    subject="[br-123] Starting auth module",
+    body_md="I'm taking br-123. Reserved src/auth/**.",
+    thread_id="br-123"
 )
 
 # Update on completion
 send_message(
     project_key, agent_name,
     to=["BlueLake", "RedMountain"],
-    subject="[bd-123] Completed",
+    subject="[br-123] Completed",
     body_md="Auth module done and tested. Released file reservations.",
-    thread_id="bd-123"
+    thread_id="br-123"
 )
 ```
 

--- a/skills/bd-to-br-migration/SKILL.md
+++ b/skills/bd-to-br-migration/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: bd-to-br-migration
+description: >-
+  Migrate docs from bd (beads) to br (beads_rust). Use when updating AGENTS.md,
+  converting bd commands, "bd sync" → "br sync --flush-only", or beads migration.
+---
+
+<!-- TOC: Philosophy | THE EXACT PROMPT | Decision Tree | Command Map | Transform Patterns | Validation Loop | Risk Tiers | References -->
+
+# bd → br Migration
+
+> **Core Philosophy:** One behavioral change, mechanical transforms. The ONLY difference is git handling—everything else is find-replace.
+
+## Why This Matters
+
+Incomplete migrations leave broken docs. Agents follow stale `bd sync` instructions, expect auto-commit, and lose work. This skill ensures **complete, verified migrations**.
+
+---
+
+## THE EXACT PROMPT — Single File Migration
+
+```
+Migrate this file from bd (beads) to br (beads_rust).
+
+Apply transforms IN THIS ORDER (order matters):
+1. Section headers: "bd (beads)" → "br (beads_rust)"
+2. Add non-invasive note after beads section header
+3. Commands: `bd X` → `br X` for ready/list/show/create/update/close/dep/stats
+4. Sync command: `bd sync` → `br sync --flush-only`
+5. Add git steps after EVERY sync:
+   git add .beads/
+   git commit -m "sync beads"
+6. Issue IDs: bd-### → br-### in thread_ids, subjects, reasons, commits
+7. Links: beads_viewer → beads_rust (if present)
+8. JSONL filename: beads.jsonl → issues.jsonl (upstream rename in br)
+
+Remove completely:
+- Daemon references
+- Auto-commit assumptions
+- Hook installation mentions
+- RPC mode
+
+Keep unchanged:
+- SQLite/WAL cautions
+- bv integration
+- Priority system (P0-P4)
+
+VERIFY after editing:
+grep -c '`bd ' file.md     # Must be 0
+grep -c 'bd sync' file.md  # Must be 0
+grep -c 'beads.jsonl' file.md  # Must be 0
+grep -c 'br sync --flush-only' file.md  # Must be > 0
+```
+
+### Why This Prompt Works
+
+- **Ordered transforms**: Dependencies exist (sync must change before adding git steps)
+- **Explicit removals**: Daemon/RPC don't exist in br—leaving them confuses agents
+- **Keep list**: Prevents accidental removal of still-valid patterns
+- **Built-in verification**: Grep commands catch missed transforms
+- **No degrees of freedom**: This is a LOW freedom task—exact transforms required
+
+---
+
+## Decision Tree: What Are You Migrating?
+
+```
+What are you migrating?
+│
+├─ Single file (AGENTS.md)
+│  │
+│  └─ Follow THE EXACT PROMPT above
+│     Use: ./scripts/verify-migration.sh file.md
+│
+├─ Multiple files (batch)
+│  │
+│  ├─ <10 files → Sequential: apply prompt to each
+│  │
+│  └─ 10+ files → Parallel subagents
+│     Batch ~10 files per agent
+│     See: [BULK.md](references/BULK.md)
+│
+└─ Verify existing migration
+   │
+   └─ Run: ./scripts/find-bd-refs.sh /path
+      Any output = incomplete migration
+```
+
+---
+
+## The One Behavioral Difference
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    bd (Go)              br (Rust)               │
+├─────────────────────────────────────────────────────────────────┤
+│  bd sync                     →    br sync --flush-only          │
+│  (auto-commits to git)            (exports JSONL only)          │
+│                                                                 │
+│                              +    git add .beads/               │
+│                              +    git commit -m "..."           │
+└─────────────────────────────────────────────────────────────────┘
+
+Everything else is literally s/bd/br/g
+
+Plus one upstream rename:
+  beads.jsonl  →  issues.jsonl  (br prefers issues.jsonl, falls back to beads.jsonl)
+```
+
+---
+
+## Command Map
+
+| bd | br | Change Type |
+|----|-----|-------------|
+| `bd ready` | `br ready` | Name only |
+| `bd list` | `br list` | Name only |
+| `bd show <id>` | `br show <id>` | Name only |
+| `bd create` | `br create` | Name only |
+| `bd update` | `br update` | Name only |
+| `bd close` | `br close` | Name only |
+| `bd dep add` | `br dep add` | Name only |
+| `bd stats` | `br stats` | Name only |
+| `bd sync` | `br sync --flush-only` + git | **BEHAVIORAL** |
+| `beads.jsonl` | `issues.jsonl` | **UPSTREAM RENAME** |
+
+---
+
+## Transform Patterns
+
+### Pattern 1: The Non-Invasive Note
+
+**Add immediately after any beads section header:**
+
+```markdown
+**Note:** `br` is non-invasive and never executes git commands. After `br sync --flush-only`, you must manually run `git add .beads/ && git commit`.
+```
+
+### Pattern 2: Sync Command Transform
+
+**Before:**
+```bash
+bd sync
+```
+
+**After:**
+```bash
+br sync --flush-only
+git add .beads/
+git commit -m "sync beads"
+```
+
+### Pattern 3: Session End Transform
+
+**Before:**
+```bash
+git add <files>
+bd sync
+git push
+```
+
+**After:**
+```bash
+git add <files>
+br sync --flush-only
+git add .beads/
+git commit -m "..."
+git push
+```
+
+### Pattern 4: Issue ID Transform
+
+**Before:**
+```markdown
+thread_id: bd-123
+subject: [bd-123] Feature implementation
+reason: bd-123
+```
+
+**After:**
+```markdown
+thread_id: br-123
+subject: [br-123] Feature implementation
+reason: br-123
+```
+
+### Pattern 5: JSONL Filename Transform
+
+`br` renamed the canonical JSONL file from `beads.jsonl` to `issues.jsonl`.
+`br` still falls back to `beads.jsonl` (legacy), but `issues.jsonl` is the default.
+
+**Before:**
+```markdown
+BV reads from `.beads/beads.jsonl`
+Fingerprint of beads.jsonl
+```
+
+**After:**
+```markdown
+BV reads from `.beads/issues.jsonl`
+Fingerprint of issues.jsonl
+```
+
+---
+
+## Validation Loop
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     VALIDATION IS MANDATORY                     │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  1. Apply transforms                                            │
+│                    ↓                                            │
+│  2. Run verification:                                           │
+│     ./scripts/verify-migration.sh file.md                       │
+│                    ↓                                            │
+│  3. If FAIL → read error → fix specific issue → goto 2          │
+│                    ↓                                            │
+│  4. Only proceed when PASS                                      │
+│                                                                 │
+│  ⚠️ Never skip verification. Incomplete migrations break agents.│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Quick Verification Commands
+
+```bash
+# MUST return 0:
+grep -c '`bd ' file.md
+grep -c 'bd sync' file.md
+grep -c 'bd ready' file.md
+grep -c 'beads\.jsonl' file.md
+
+# MUST return > 0 (if file has sync sections):
+grep -c 'br sync --flush-only' file.md
+grep -c 'git add .beads/' file.md
+```
+
+---
+
+## Risk Tiers
+
+| Operation | Risk | Freedom |
+|-----------|------|---------|
+| Command renames (`bd` → `br`) | Low | Mechanical—no judgment |
+| Sync transform + git steps | Medium | MUST add git steps |
+| Removing daemon refs | Medium | Verify not removing valid content |
+| Bulk migration (10+ files) | High | Use subagents with verification |
+
+### Degrees of Freedom: LOW
+
+This is a **deterministic transformation**. There is ONE correct output for each input.
+
+- No creative interpretation
+- No optional improvements
+- No stylistic choices
+- Apply transforms EXACTLY as specified
+
+---
+
+## What Gets Removed
+
+| Pattern | Why Remove | Verify Absent |
+|---------|------------|---------------|
+| "bd daemon" | br has no daemon | `grep -i daemon` |
+| "auto-commits" | br never commits | `grep -i "auto.*commit"` |
+| "git hooks" | br installs none | `grep -i "hook"` |
+| "RPC mode" | br has no RPC | `grep -i "rpc"` |
+
+---
+
+## What Stays Unchanged
+
+| Pattern | Why Keep |
+|---------|----------|
+| SQLite/WAL cautions | br still uses WAL |
+| bv integration | Works with both |
+| Priority P0-P4 | Same system |
+| Issue types | Same system |
+| Dependency tracking | Same system |
+| `.beads/` as source of truth | Same system |
+
+---
+
+## Before/After Example
+
+### Before (bd)
+```markdown
+## Issue Tracking with bd (beads)
+
+Key invariants:
+- `.beads/` is authoritative
+
+### Agent workflow:
+1. `bd ready` to find work
+2. `bd update <id> --status in_progress`
+3. Implement
+4. `bd close <id>`
+5. `bd sync` commits changes
+```
+
+### After (br)
+```markdown
+## Issue Tracking with br (beads_rust)
+
+**Note:** `br` is non-invasive and never executes git commands. After `br sync --flush-only`, you must manually run `git add .beads/ && git commit`.
+
+Key invariants:
+- `.beads/` is authoritative
+
+### Agent workflow:
+1. `br ready` to find work
+2. `br update <id> --status in_progress`
+3. Implement
+4. `br close <id>`
+5. Sync and commit:
+   ```bash
+   br sync --flush-only
+   git add .beads/
+   git commit -m "sync beads"
+   ```
+```
+
+---
+
+## References
+
+| Need | Reference |
+|------|-----------|
+| Complete before/after examples | [TRANSFORMS.md](references/TRANSFORMS.md) |
+| Bulk migration strategy | [BULK.md](references/BULK.md) |
+| Common mistakes & fixes | [PITFALLS.md](references/PITFALLS.md) |
+
+---
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `./scripts/find-bd-refs.sh /path` | Find files needing migration |
+| `./scripts/verify-migration.sh file.md` | Verify migration complete |
+
+---
+
+## Validation
+
+```bash
+# Full verification
+./scripts/verify-migration.sh /path/to/AGENTS.md
+
+# Quick check (should return nothing)
+grep '`bd ' /path/to/AGENTS.md
+```
+
+If any bd references remain → migration incomplete → re-apply transforms.

--- a/skills/beads-workflow/SKILL.md
+++ b/skills/beads-workflow/SKILL.md
@@ -48,7 +48,7 @@ Key properties:
 ### THE EXACT PROMPT — Plan to Beads Conversion (Claude Code + Opus 4.5)
 
 ```
-OK so now read ALL of PLAN_TO_CREATE_GH_PAGES_WEB_EXPORT_APP.md; please take ALL of that and elaborate on it and use it to create a comprehensive and granular set of beads for all this with tasks, subtasks, and dependency structure overlaid, with detailed comments so that the whole thing is totally self-contained and self-documenting (including relevant background, reasoning/justification, considerations, etc.-- anything we'd want our "future self" to know about the goals and intentions and thought process and how it serves the over-arching goals of the project.). The beads should be so detailed that we never need to consult back to the original markdown plan document. Remember to ONLY use the `bd` tool to create and modify the beads and add the dependencies. Use ultrathink.
+OK so now read ALL of PLAN_TO_CREATE_GH_PAGES_WEB_EXPORT_APP.md; please take ALL of that and elaborate on it and use it to create a comprehensive and granular set of beads for all this with tasks, subtasks, and dependency structure overlaid, with detailed comments so that the whole thing is totally self-contained and self-documenting (including relevant background, reasoning/justification, considerations, etc.-- anything we'd want our "future self" to know about the goals and intentions and thought process and how it serves the over-arching goals of the project.). The beads should be so detailed that we never need to consult back to the original markdown plan document. Remember to ONLY use the `br` tool to create and modify the beads and add the dependencies. Use ultrathink.
 ```
 
 **Note:** Replace `PLAN_TO_CREATE_GH_PAGES_WEB_EXPORT_APP.md` with your actual plan filename.
@@ -56,7 +56,7 @@ OK so now read ALL of PLAN_TO_CREATE_GH_PAGES_WEB_EXPORT_APP.md; please take ALL
 ### Alternative Shorter Version
 
 ```
-OK so please take ALL of that and elaborate on it more and then create a comprehensive and granular set of beads for all this with tasks, subtasks, and dependency structure overlaid, with detailed comments so that the whole thing is totally self-contained and self-documenting (including relevant background, reasoning/justification, considerations, etc.-- anything we'd want our "future self" to know about the goals and intentions and thought process and how it serves the over-arching goals of the project.)  Use only the `bd` tool to create and modify the beads and add the dependencies. Use ultrathink.
+OK so please take ALL of that and elaborate on it more and then create a comprehensive and granular set of beads for all this with tasks, subtasks, and dependency structure overlaid, with detailed comments so that the whole thing is totally self-contained and self-documenting (including relevant background, reasoning/justification, considerations, etc.-- anything we'd want our "future self" to know about the goals and intentions and thought process and how it serves the over-arching goals of the project.)  Use only the `br` tool to create and modify the beads and add the dependencies. Use ultrathink.
 ```
 
 ### What This Creates
@@ -90,7 +90,7 @@ Reread AGENTS dot md so it's still fresh in your mind. Check over each bead supe
 
 DO NOT OVERSIMPLIFY THINGS! DO NOT LOSE ANY FEATURES OR FUNCTIONALITY!
 
-Also, make sure that as part of these beads, we include comprehensive unit tests and e2e test scripts with great, detailed logging so we can be sure that everything is working perfectly after implementation. Remember to ONLY use the `bd` tool to create and modify the beads and to add the dependencies to beads. Use ultrathink.
+Also, make sure that as part of these beads, we include comprehensive unit tests and e2e test scripts with great, detailed logging so we can be sure that everything is working perfectly after implementation. Remember to ONLY use the `br` tool to create and modify the beads and to add the dependencies to beads. Use ultrathink.
 ```
 
 ### Polishing Protocol
@@ -116,7 +116,7 @@ First read ALL of the AGENTS dot md file and README dot md file super carefully 
 ### THE EXACT PROMPT — Then Review Beads
 
 ```
-We recently transformed a markdown plan file into a bunch of new beads. I want you to very carefully review and analyze these using `bd` and `bv`.
+We recently transformed a markdown plan file into a bunch of new beads. I want you to very carefully review and analyze these using `br` and `bv`.
 ```
 
 Then follow up with the standard polish prompt.
@@ -149,28 +149,35 @@ Before implementation, verify each bead:
 
 ---
 
-## Using bd (Beads CLI)
+## Using br (Beads CLI)
+
+**Note:** `br` is non-invasive and never executes git commands. After `br sync --flush-only`, you must manually run `git add .beads/ && git commit`.
 
 ### Basic Commands
 
 ```bash
 # Initialize beads in project
-bd init
+br init
 
 # Create a new bead
-bd create "Implement user authentication" -t feature -p 1
+br create "Implement user authentication" -t feature -p 1
 
 # Add dependencies
-bd depend BD-123 BD-100  # BD-123 depends on BD-100
+br dep add BD-123 BD-100  # BD-123 depends on BD-100
 
 # Update status
-bd update BD-123 --status in_progress
+br update BD-123 --status in_progress
 
 # Close a bead
-bd close BD-123 --reason "Completed and tested"
+br close BD-123 --reason "Completed and tested"
 
 # List ready beads (no blockers)
-bd ready --json
+br ready --json
+
+# Sync and commit
+br sync --flush-only
+git add .beads/
+git commit -m "sync beads"
 ```
 
 ### Robot Mode for Agents
@@ -197,28 +204,33 @@ bv --robot-insights
 
 ### Conventions
 
-- Use Beads issue ID as Mail `thread_id`: `send_message(..., thread_id="bd-123")`
-- Prefix subjects: `[bd-123] Starting auth refactor`
-- Include issue ID in file reservation `reason`: `file_reservation_paths(..., reason="bd-123")`
+- Use Beads issue ID as Mail `thread_id`: `send_message(..., thread_id="br-123")`
+- Prefix subjects: `[br-123] Starting auth refactor`
+- Include issue ID in file reservation `reason`: `file_reservation_paths(..., reason="br-123")`
 
 ### Typical Flow
 
 ```bash
 # 1. Pick ready work
-bd ready --json
+br ready --json
 
 # 2. Reserve files
-file_reservation_paths(project_key, agent_name, ["src/**"], reason="bd-123")
+file_reservation_paths(project_key, agent_name, ["src/**"], reason="br-123")
 
 # 3. Announce start
-send_message(..., thread_id="bd-123", subject="[bd-123] Starting work")
+send_message(..., thread_id="br-123", subject="[br-123] Starting work")
 
 # 4. Work on the bead
 # ...
 
 # 5. Complete
-bd close bd-123 --reason "Completed"
+br close br-123 --reason "Completed"
 release_file_reservations(project_key, agent_name)
+
+# 6. Sync and commit
+br sync --flush-only
+git add .beads/
+git commit -m "close br-123"
 ```
 
 ---
@@ -298,12 +310,12 @@ to reduce friction.
 
 ### Plan to Beads (Full)
 ```
-OK so now read ALL of PLAN_TO_CREATE_GH_PAGES_WEB_EXPORT_APP.md; please take ALL of that and elaborate on it and use it to create a comprehensive and granular set of beads for all this with tasks, subtasks, and dependency structure overlaid, with detailed comments so that the whole thing is totally self-contained and self-documenting (including relevant background, reasoning/justification, considerations, etc.-- anything we'd want our "future self" to know about the goals and intentions and thought process and how it serves the over-arching goals of the project.). The beads should be so detailed that we never need to consult back to the original markdown plan document. Remember to ONLY use the `bd` tool to create and modify the beads and add the dependencies. Use ultrathink.
+OK so now read ALL of PLAN_TO_CREATE_GH_PAGES_WEB_EXPORT_APP.md; please take ALL of that and elaborate on it and use it to create a comprehensive and granular set of beads for all this with tasks, subtasks, and dependency structure overlaid, with detailed comments so that the whole thing is totally self-contained and self-documenting (including relevant background, reasoning/justification, considerations, etc.-- anything we'd want our "future self" to know about the goals and intentions and thought process and how it serves the over-arching goals of the project.). The beads should be so detailed that we never need to consult back to the original markdown plan document. Remember to ONLY use the `br` tool to create and modify the beads and add the dependencies. Use ultrathink.
 ```
 
 ### Plan to Beads (Short)
 ```
-OK so please take ALL of that and elaborate on it more and then create a comprehensive and granular set of beads for all this with tasks, subtasks, and dependency structure overlaid, with detailed comments so that the whole thing is totally self-contained and self-documenting (including relevant background, reasoning/justification, considerations, etc.-- anything we'd want our "future self" to know about the goals and intentions and thought process and how it serves the over-arching goals of the project.)  Use only the `bd` tool to create and modify the beads and add the dependencies. Use ultrathink.
+OK so please take ALL of that and elaborate on it more and then create a comprehensive and granular set of beads for all this with tasks, subtasks, and dependency structure overlaid, with detailed comments so that the whole thing is totally self-contained and self-documenting (including relevant background, reasoning/justification, considerations, etc.-- anything we'd want our "future self" to know about the goals and intentions and thought process and how it serves the over-arching goals of the project.)  Use only the `br` tool to create and modify the beads and add the dependencies. Use ultrathink.
 ```
 
 ### Polish Beads (Full)
@@ -317,7 +329,7 @@ Reread AGENTS dot md so it's still fresh in your mind. Check over each bead supe
 
 DO NOT OVERSIMPLIFY THINGS! DO NOT LOSE ANY FEATURES OR FUNCTIONALITY!
 
-Also, make sure that as part of these beads, we include comprehensive unit tests and e2e test scripts with great, detailed logging so we can be sure that everything is working perfectly after implementation. Remember to ONLY use the `bd` tool to create and modify the beads and to add the dependencies to beads. Use ultrathink.
+Also, make sure that as part of these beads, we include comprehensive unit tests and e2e test scripts with great, detailed logging so we can be sure that everything is working perfectly after implementation. Remember to ONLY use the `br` tool to create and modify the beads and to add the dependencies to beads. Use ultrathink.
 ```
 
 ### Fresh Session — Context
@@ -327,7 +339,7 @@ First read ALL of the AGENTS dot md file and README dot md file super carefully 
 
 ### Fresh Session — Review
 ```
-We recently transformed a markdown plan file into a bunch of new beads. I want you to very carefully review and analyze these using `bd` and `bv`.
+We recently transformed a markdown plan file into a bunch of new beads. I want you to very carefully review and analyze these using `br` and `bv`.
 ```
 
 ### Add Test Coverage

--- a/skills/bv/SKILL.md
+++ b/skills/bv/SKILL.md
@@ -131,12 +131,12 @@ All robot JSON includes:
 {
   "quick_ref": { "open": 45, "blocked": 12, "top_picks": [...] },
   "recommendations": [
-    { "id": "bd-123", "score": 0.85, "reason": "Unblocks 5 tasks", "unblock_info": {...} }
+    { "id": "br-123", "score": 0.85, "reason": "Unblocks 5 tasks", "unblock_info": {...} }
   ],
   "quick_wins": [...],
   "blockers_to_clear": [...],
   "project_health": { "distributions": {...}, "graph_metrics": {...} },
-  "commands": { "claim": "br update bd-123 --status in_progress", "view": "bv --bead bd-123" }
+  "commands": { "claim": "br update br-123 --status in_progress", "view": "bv --bead br-123" }
 }
 ```
 
@@ -144,12 +144,12 @@ All robot JSON includes:
 
 ```json
 {
-  "bottlenecks": [{ "id": "bd-123", "value": 0.45 }],
-  "keystones": [{ "id": "bd-456", "value": 12.0 }],
+  "bottlenecks": [{ "id": "br-123", "value": 0.45 }],
+  "keystones": [{ "id": "br-456", "value": 12.0 }],
   "influencers": [...],
   "hubs": [...],
   "authorities": [...],
-  "cycles": [["bd-A", "bd-B", "bd-A"]],
+  "cycles": [["br-A", "br-B", "br-A"]],
   "clusterDensity": 0.045,
   "status": { "pagerank": "computed", "betweenness": "computed", ... }
 }
@@ -220,8 +220,8 @@ br init                    # Initialize beads in project
 br create "Task title"     # Create a bead
 br list                    # List beads
 br ready                   # Show actionable beads
-br update bd-123 --status in_progress  # Claim a bead
-br close bd-123            # Close a bead
+br update br-123 --status in_progress  # Claim a bead
+br close br-123            # Close a bead
 br sync --flush-only       # Export DB to JSONL
 git add .beads/            # Stage tracker state
 git commit -m "sync beads" # Commit manually
@@ -242,7 +242,7 @@ send_message(..., thread_id="br-123", subject="[br-123] Starting...")
 bv --robot-graph                              # JSON (default)
 bv --robot-graph --graph-format=dot           # Graphviz DOT
 bv --robot-graph --graph-format=mermaid       # Mermaid diagram
-bv --robot-graph --graph-root=bd-123 --graph-depth=3  # Subgraph
+bv --robot-graph --graph-root=br-123 --graph-depth=3  # Subgraph
 bv --export-graph report.html                 # Interactive HTML
 ```
 

--- a/skills/bv/SKILL.md
+++ b/skills/bv/SKILL.md
@@ -5,18 +5,18 @@ description: "Beads Viewer - Graph-aware triage engine for Beads projects. Compu
 
 # BV - Beads Viewer
 
-A graph-aware triage engine for Beads projects (`.beads/beads.jsonl`). Computes 9 graph metrics, generates execution plans, and provides deterministic recommendations. Human TUI for browsing; robot flags for AI agents.
+A graph-aware triage engine for Beads projects (`.beads/issues.jsonl`). Computes 9 graph metrics, generates execution plans, and provides deterministic recommendations. Human TUI for browsing; robot flags for AI agents.
 
 ## Why BV vs Raw Beads
 
-| Capability | Raw beads.jsonl | BV Robot Mode |
+| Capability | Raw issues.jsonl | BV Robot Mode |
 |------------|-----------------|---------------|
 | Query | "List all issues" | "List the top 5 bottlenecks blocking the release" |
 | Context Cost | High (linear with issue count) | Low (fixed summary struct) |
 | Graph Logic | Agent must compute | Pre-computed (PageRank, betweenness, cycles) |
 | Safety | Agent might miss cycles | Cycles explicitly flagged |
 
-Use BV instead of parsing beads.jsonl directly. It computes graph metrics deterministically.
+Use BV instead of parsing issues.jsonl directly. It computes graph metrics deterministically.
 
 ## CRITICAL: Robot Mode for Agents
 
@@ -121,7 +121,7 @@ bv --robot-triage --robot-triage-by-label    # Group by domain
 ## Robot Output Structure
 
 All robot JSON includes:
-- `data_hash` - Fingerprint of beads.jsonl (verify consistency)
+- `data_hash` - Fingerprint of issues.jsonl (verify consistency)
 - `status` - Per-metric state: `computed|approx|timeout|skipped`
 - `as_of` / `as_of_commit` - Present when using `--as-of`
 
@@ -136,7 +136,7 @@ All robot JSON includes:
   "quick_wins": [...],
   "blockers_to_clear": [...],
   "project_health": { "distributions": {...}, "graph_metrics": {...} },
-  "commands": { "claim": "bd claim bd-123", "view": "bv --bead bd-123" }
+  "commands": { "claim": "br update bd-123 --status in_progress", "view": "bv --bead bd-123" }
 }
 ```
 
@@ -180,12 +180,17 @@ if [ "$CYCLES" != "[]" ]; then
 fi
 
 # 3. Claim the task
-bd claim "$NEXT_TASK"
+br update "$NEXT_TASK" --status in_progress
 
 # 4. Work on it...
 
 # 5. Close when done
-bd close "$NEXT_TASK"
+br close "$NEXT_TASK"
+
+# 6. Sync and commit
+br sync --flush-only
+git add .beads/
+git commit -m "close $NEXT_TASK"
 ```
 
 ## TUI Views (for Humans)
@@ -204,17 +209,22 @@ When running `bv` interactively (not for agents):
 | `f` | Flow matrix (cross-label dependencies) |
 | `]` | Attention view (label priority ranking) |
 
-## Integration with bd CLI
+## Integration with br CLI
 
-BV reads from `.beads/beads.jsonl` created by the `bd` CLI:
+**Note:** `br` is non-invasive and never executes git commands. After `br sync --flush-only`, you must manually run `git add .beads/ && git commit`.
+
+BV reads from `.beads/issues.jsonl` created by the `br` CLI:
 
 ```bash
-bd init                    # Initialize beads in project
-bd create "Task title"     # Create a bead
-bd list                    # List beads
-bd ready                   # Show actionable beads
-bd claim bd-123            # Claim a bead
-bd close bd-123            # Close a bead
+br init                    # Initialize beads in project
+br create "Task title"     # Create a bead
+br list                    # List beads
+br ready                   # Show actionable beads
+br update bd-123 --status in_progress  # Claim a bead
+br close bd-123            # Close a bead
+br sync --flush-only       # Export DB to JSONL
+git add .beads/            # Stage tracker state
+git commit -m "sync beads" # Commit manually
 ```
 
 ## Integration with Agent Mail
@@ -222,8 +232,8 @@ bd close bd-123            # Close a bead
 Use bead IDs as thread IDs for coordination:
 
 ```
-file_reservation_paths(..., reason="bd-123")
-send_message(..., thread_id="bd-123", subject="[bd-123] Starting...")
+file_reservation_paths(..., reason="br-123")
+send_message(..., thread_id="br-123", subject="[br-123] Starting...")
 ```
 
 ## Graph Export Formats
@@ -252,7 +262,7 @@ bv --robot-diff --diff-since HEAD~30  # Changes in last 30 commits
 | Issue | Fix |
 |-------|-----|
 | TUI blocks agent | Use `--robot-*` flags only |
-| Stale metrics | Check `status` field, results cached by `data_hash` |
+| Stale metrics | Check `status` field, results cached by `data_hash` of issues.jsonl |
 | Missing cycles | Run `--robot-insights`, check `.cycles` |
 | Wrong recommendations | Use `--recipe actionable` to filter to ready work |
 
@@ -260,5 +270,5 @@ bv --robot-diff --diff-since HEAD~30  # Changes in last 30 commits
 
 - Phase 1 metrics (degree, topo, density): instant
 - Phase 2 metrics (PageRank, betweenness, etc.): 500ms timeout
-- Results cached by `data_hash`
+- Results cached by `data_hash` of issues.jsonl
 - Prefer `--robot-plan` over `--robot-insights` when speed matters

--- a/skills/de-slopify/SKILL.md
+++ b/skills/de-slopify/SKILL.md
@@ -182,8 +182,8 @@ Install the tool and run your first command in under a minute.
 ### As Part of Bead Workflow
 
 ```bash
-bd create "De-slopify README.md" -t docs -p 3
-bd create "De-slopify API documentation" -t docs -p 3
+br create "De-slopify README.md" -t docs -p 3
+br create "De-slopify API documentation" -t docs -p 3
 ```
 
 ### As Final Pass Before Commit

--- a/skills/ntm/SKILL.md
+++ b/skills/ntm/SKILL.md
@@ -248,7 +248,7 @@ ntm --robot-health              # Project health
 ntm --robot-send=SESSION --msg="Fix auth" --type=claude
 ntm --robot-spawn=SESSION --spawn-cc=2 --spawn-wait
 ntm --robot-interrupt=SESSION
-ntm --robot-assign=SESSION --assign-beads=bd-1,bd-2
+ntm --robot-assign=SESSION --assign-beads=br-1,br-2
 ntm --robot-replay=SESSION --replay-id=ID
 ```
 

--- a/skills/tanstack-integration/SKILL.md
+++ b/skills/tanstack-integration/SKILL.md
@@ -245,10 +245,10 @@ const table = useReactTable({
 ## Creating Beads for TanStack Work
 
 ```bash
-bd create "Evaluate TanStack Query opportunities" -t enhancement -p 3
-bd create "Migrate user data fetching to TanStack Query" -t enhancement -p 2
-bd create "Implement data table with TanStack Table" -t feature -p 2
-bd create "Add TanStack Virtual to chat message list" -t performance -p 2
+br create "Evaluate TanStack Query opportunities" -t enhancement -p 3
+br create "Migrate user data fetching to TanStack Query" -t enhancement -p 2
+br create "Implement data table with TanStack Table" -t feature -p 2
+br create "Add TanStack Virtual to chat message list" -t performance -p 2
 ```
 
 ---

--- a/skills/ui-ux-polish/SKILL.md
+++ b/skills/ui-ux-polish/SKILL.md
@@ -192,10 +192,10 @@ These small changes compound. An app after 10 passes looks dramatically better t
 For systematic UI/UX work, create beads:
 
 ```bash
-bd create "Polish homepage UI/UX for desktop" -t enhancement -p 2
-bd create "Polish homepage UI/UX for mobile" -t enhancement -p 2
-bd create "Polish dashboard UI/UX for desktop" -t enhancement -p 2
-bd create "Polish dashboard UI/UX for mobile" -t enhancement -p 2
+br create "Polish homepage UI/UX for desktop" -t enhancement -p 2
+br create "Polish homepage UI/UX for mobile" -t enhancement -p 2
+br create "Polish dashboard UI/UX for desktop" -t enhancement -p 2
+br create "Polish dashboard UI/UX for mobile" -t enhancement -p 2
 ```
 
 This lets agents work on UI/UX polish as part of the normal bead workflow.


### PR DESCRIPTION
## Summary

- **Migrate bd → br** across 8 existing skills (bv, beads-workflow, agent-mail, agent-swarm-workflow, de-slopify, tanstack-integration, ui-ux-polish, ntm)
- **Add new `bd-to-br-migration` skill** with the exact prompt, command map, transform patterns, validation loop, and the upstream `beads.jsonl` → `issues.jsonl` rename
- **Update README** to include the new skill in the Workflow Methodologies table

### What changed per skill

| Skill | Changes |
|-------|---------|
| **bv** | `beads.jsonl`→`issues.jsonl` (7 places), `bd claim`→`br update --status`, sync+git steps, all `bd-###` IDs→`br-###` |
| **beads-workflow** | All commands `bd init/create/dep/update/close/ready`→`br`, added non-invasive note, sync+git steps, `bd-###`→`br-###` |
| **agent-mail** | `bd-###`→`br-###` in examples, `Use bd`→`Use br`, sync step 6 |
| **agent-swarm-workflow** | `bd-123`→`br-123` (6 places) |
| **de-slopify** | `bd create`→`br create` (2 places) |
| **tanstack-integration** | `bd create`→`br create` (4 places) |
| **ui-ux-polish** | `bd create`→`br create` (4 places) |
| **ntm** | `assign-beads=bd-1,bd-2`→`br-1,br-2` |

### Key behavioral difference

`bd sync` (auto-commits) → `br sync --flush-only` + manual `git add .beads/ && git commit`

### Upstream JSONL rename

`beads_rust` renamed the canonical JSONL from `beads.jsonl` to `issues.jsonl` (with legacy fallback). All skills updated accordingly.

## Verification

```bash
# All return 0 (no stale refs outside migration skill):
grep -r '`bd ' skills/ --include='*.md' | grep -v bd-to-br-migration | grep -v '→\|Before\|before'
grep -r 'bd-[0-9]' skills/ --include='*.md' | grep -v bd-to-br-migration | grep -v '→\|Before\|before'
grep -r 'beads\.jsonl' skills/ --include='*.md' | grep -v bd-to-br-migration | grep -v 'Legacy\|legacy\|fallback'
```

## Test plan

- [x] Grep verification: zero stale `bd` command refs outside migration skill
- [x] Grep verification: zero stale `bd-###` issue IDs outside migration skill
- [x] Grep verification: zero stale `beads.jsonl` refs outside migration skill
- [x] All skills retain valid YAML frontmatter
- [ ] Upstream review: confirm `br` CLI flag correspondence is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)